### PR TITLE
Adding django-elasticsearch-dsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A curated list of awesome frameworks, libraries and software made in Bangladesh
     * [maateen/battery-monitor](https://github.com/maateen/battery-monitor) - A utility tool, notifies user about charging, discharging and not charging state of the battery on Linux.
     * [safwanrahman/django-webpush](https://github.com/safwanrahman/django-webpush) - Web Push Notification Package for Django.
     * [alaminopu/pdf_downloader](https://github.com/alaminopu/pdf_downloader) - A Scrapy Spider for downloading PDF files from a webpage.
+    * [django-es/django-elasticsearch-dsl](https://github.com/django-es/django-elasticsearch-dsl) - A package that allows indexing of django models in Elasticsearch.
 - Rust
     * [alaminopu/kctl](https://github.com/alaminopu/kctl) - A CLI wrapper for making kubernetes commands much easier
 - Swift


### PR DESCRIPTION
I am currently maintaining the package. So I think this can be added in the list.